### PR TITLE
NSNumberFormatter Bug Fix

### DIFF
--- a/SVGPath/SVGPath.swift
+++ b/SVGPath/SVGPath.swift
@@ -91,7 +91,7 @@ public class SVGPath {
 // MARK: Numbers
 
 private let numberSet = NSCharacterSet(charactersInString: "-.0123456789eE")
-private let numberFormatter = NSNumberFormatter()
+private let numberFormatter = createNumberFormatter()
 
 public extension SVGPath {
     class func parseNumbers (numbers: String) -> [CGFloat] {
@@ -175,6 +175,14 @@ public struct SVGCommand {
         }
         return self
     }
+}
+
+// MARK: NSNumberFormatter helpers
+
+private func createNumberFormatter() -> NSNumberFormatter {
+    let numberFormatter = NSNumberFormatter()
+    numberFormatter.locale = NSLocale(localeIdentifier: "en_US")
+    return numberFormatter
 }
 
 // MARK: CGPoint helpers


### PR DESCRIPTION
Some locales(for example Croatian) present decimal points with comma instead of dot. In our case that means that localized numberFormatter will parse SVG path string wrong.
