### PR TITLE
Add ability to offset path

### DIFF
--- a/SVGPath.xcodeproj/project.pbxproj
+++ b/SVGPath.xcodeproj/project.pbxproj
@@ -380,7 +380,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -402,7 +402,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -417,7 +417,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -429,7 +429,7 @@
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SVGPath/SVGPath.swift
+++ b/SVGPath/SVGPath.swift
@@ -12,20 +12,24 @@ import CoreGraphics
 // MARK: UIBezierPath
 
 public extension UIBezierPath {
-    convenience init (svgPath: String) {
+    convenience init (svgPath: String, offset: CGFloat = 0) {
         self.init()
-        applyCommands(from: SVGPath(svgPath))
+        applyCommands(from: SVGPath(svgPath), offset: offset)
     }
 }
 
 private extension UIBezierPath {
-    func applyCommands(from svgPath: SVGPath) {
+    func applyCommands(from svgPath: SVGPath, offset: CGFloat) {
         for command in svgPath.commands {
+            let point = CGPoint(x: command.point.x - offset, y: command.point.y - offset)
+            let controlPoint1 = CGPoint(x: command.control1.x - offset, y: command.control1.y - offset)
+            let controlPoint2 = CGPoint(x: command.control2.x - offset, y: command.control2.y - offset)
+            
             switch command.type {
-            case .move: move(to: command.point)
-            case .line: addLine(to: command.point)
-            case .quadCurve: addQuadCurve(to: command.point, controlPoint: command.control1)
-            case .cubeCurve: addCurve(to: command.point, controlPoint1: command.control1, controlPoint2: command.control2)
+            case .move: move(to: point)
+            case .line: addLine(to: point)
+            case .quadCurve: addQuadCurve(to: point, controlPoint: controlPoint1)
+            case .cubeCurve: addCurve(to: point, controlPoint1: controlPoint1, controlPoint2: controlPoint2)
             case .close: close()
             }
         }

--- a/SVGPath/SVGPath.swift
+++ b/SVGPath/SVGPath.swift
@@ -49,7 +49,7 @@ public class SVGPath {
     private var numbers = ""
 
     public init (_ string: String) {
-        for char in string.characters {
+        for char in string {
             switch char {
             case "M": use(.absolute, 2, move)
             case "m": use(.relative, 2, move)
@@ -120,7 +120,7 @@ public extension SVGPath {
         
         all.append(curr)
         
-        return all.map { CGFloat(NSDecimalNumber(string: $0, locale: locale)) }
+        return all.map { CGFloat(truncating: NSDecimalNumber(string: $0, locale: locale)) }
     }
 }
 

--- a/SVGPathTests/UIBezierPathTests.swift
+++ b/SVGPathTests/UIBezierPathTests.swift
@@ -113,4 +113,19 @@ class UIBezierPathTests: XCTestCase {
         XCTAssert(!path.contains(CGPoint(x: 4.99, y: 6.01)), "square should not contain 4.99, 6.01")
         XCTAssert(!path.contains(CGPoint(x: 4.01, y: 6.01)), "square should not contain 4.01, 6.01")
     }
+    
+    func testOffset() {
+        // CubeCurve with an offset of 2.0
+        let path = UIBezierPath(svgPath: "M2 4C4 4 4 6 2 6Z", offset: 2)
+        
+        // 4 corners
+        XCTAssert( path.contains(CGPoint(x: 0.01, y: 2.01)), "curve should contain 0.01, 2.01")
+        XCTAssert(!path.contains(CGPoint(x: 1.99, y: 2.01)), "curve should not contain 1.99, 2.01")
+        XCTAssert(!path.contains(CGPoint(x: 1.99, y: 3.99)), "curve should not contain 1.99, 3.99")
+        XCTAssert( path.contains(CGPoint(x: 0.01, y: 3.99)), "curve should contain 0.01, 3.99")
+        
+        // either side of the halfway point of the curve
+        XCTAssert( path.contains(CGPoint(x: 1.49, y: 3)), "curve should contain 1.49, 3")
+        XCTAssert(!path.contains(CGPoint(x: 1.51, y: 3)), "curve should not contain 1.51, 3")
+    }
 }


### PR DESCRIPTION
Thank you so much for making this library

**Added new offset parameter**
Use case for this new parameter is that Apple offsets their new UIPointer in iPadOS 13.4. I'm using this library to create a BezierPath from an SVG to change the pointer shape. Added this as an optional parameter so it doesn't break existing implementations.  


**Updated to Swift 5**
Syntax is now Swift 5 conform and updated the project file accordingly  


**Test case for offset**
New test case to make sure the offset works as expected.